### PR TITLE
fix: change csrf token key

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection;
 
-const REQUEST_ID_KEY = "X_CSRF_TOKEN";
+const REQUEST_ID_KEY = "CSRF-PROTECTION-TOKEN";
 
 const FORBIDDEN_REQUEST_MESSAGE = "%s A request has been blocked";

--- a/tests/unit/Http/CsrfPostRoutingMiddlewareTest.php
+++ b/tests/unit/Http/CsrfPostRoutingMiddlewareTest.php
@@ -27,6 +27,8 @@ use const Phpolar\CsrfProtection\REQUEST_ID_KEY;
  */
 final class CsrfPostRoutingMiddlewareTest extends TestCase
 {
+    private $tokenKey = REQUEST_ID_KEY;
+
     private StreamInterface $stream;
 
     public function tearDown(): void
@@ -67,17 +69,17 @@ final class CsrfPostRoutingMiddlewareTest extends TestCase
         $token = $tokenStorage->queryOne(1);
         $tokenForUri = urlencode($token->asString());
         $expected = <<<HTML
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         <form action="somewhere" method="post">
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         <form>
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         <form>
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
         HTML;
         $actual = $responseWithFormKeys->getBody()->getContents();

--- a/tests/unit/Http/ResponseFilterContextTest.php
+++ b/tests/unit/Http/ResponseFilterContextTest.php
@@ -11,6 +11,8 @@ use Phpolar\CsrfProtection\Tests\Stubs\ResponseFactoryStub;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
+use const Phpolar\CsrfProtection\REQUEST_ID_KEY;
+
 /**
  * @covers \Phpolar\CsrfProtection\Http\ResponseFilterContext
  * @covers \Phpolar\CsrfProtection\Http\ResponseFilterPatternStrategy
@@ -19,6 +21,8 @@ use Psr\Http\Message\StreamInterface;
  */
 final class ResponseFilterContextTest extends TestCase
 {
+    private string $tokenKey = REQUEST_ID_KEY;
+
     private StreamInterface $stream;
 
     public function tearDown(): void
@@ -45,13 +49,13 @@ final class ResponseFilterContextTest extends TestCase
         HTML;
         $expected = <<<HTML
         <form action="somewhere" method="post">
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
         <form>
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
         <form>
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
         HTML;
         $this->stream = $streamFactory->createStream($forms);
@@ -104,9 +108,9 @@ final class ResponseFilterContextTest extends TestCase
         <a href="http://somewhere.com?action=doSomething">some text</a>
         HTML;
         $expected = <<<HTML
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         HTML;
         $this->stream = $streamFactory->createStream($links);
         $response = $responseFactory->createResponse();
@@ -135,17 +139,17 @@ final class ResponseFilterContextTest extends TestCase
         <form></form>
         HTML;
         $expected = <<<HTML
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         <form action="somewhere" method="post">
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         <form>
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
-        <a href="http://somewhere.com?X_CSRF_TOKEN={$tokenForUri}&action=doSomething">some text</a>
+        <a href="http://somewhere.com?{$this->tokenKey}={$tokenForUri}&action=doSomething">some text</a>
         <form>
-            <input type="hidden" name="X_CSRF_TOKEN" value="{$token->asString()}" />
+            <input type="hidden" name="{$this->tokenKey}" value="{$token->asString()}" />
         </form>
         HTML;
         $this->stream = $streamFactory->createStream($links);


### PR DESCRIPTION
The change was based on RFC 6648. See https://datatracker.ietf.org/doc/html/rfc6648.