### PR TITLE
feat: allow extending middleware

### DIFF
--- a/src/Http/CsrfPostRoutingMiddleware.php
+++ b/src/Http/CsrfPostRoutingMiddleware.php
@@ -15,7 +15,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Adds support for CSRF attack mitigation
  */
-final class CsrfPostRoutingMiddleware extends AbstractCsrfProtectionMiddleware
+class CsrfPostRoutingMiddleware extends AbstractCsrfProtectionMiddleware
 {
     public function __construct(
         private ResponseInterface $routingResponse,

--- a/src/Http/CsrfPreRoutingMiddleware.php
+++ b/src/Http/CsrfPreRoutingMiddleware.php
@@ -12,7 +12,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Adds support for CSRF attack mitigation
  */
-final class CsrfPreRoutingMiddleware extends AbstractCsrfProtectionMiddleware
+class CsrfPreRoutingMiddleware extends AbstractCsrfProtectionMiddleware
 {
     /**
      * Provide protection against CSRF attack.


### PR DESCRIPTION
Marking the classes as final prevented the creation of mocks in tests.