### PR TITLE
feat(CsrfPostRoutingMiddlewareFactory): allow extending

### DIFF
--- a/src/Http/CsrfPostRoutingMiddlewareFactory.php
+++ b/src/Http/CsrfPostRoutingMiddlewareFactory.php
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
  * the routing response which will be created
  * after dependency injection is configured.
  */
-final class CsrfPostRoutingMiddlewareFactory
+class CsrfPostRoutingMiddlewareFactory
 {
     public function __construct(
         protected ResponseFactoryInterface $responseFactory,


### PR DESCRIPTION
Creating mocks is not possible on classes declared "final".