### PR TITLE
fix(SessionTokenStorage): load tokens from session variable

### DIFF
--- a/src/Storage/SessionTokenStorage.php
+++ b/src/Storage/SessionTokenStorage.php
@@ -35,11 +35,13 @@ final class SessionTokenStorage extends AbstractTokenStorage
 
     public function queryAll(): array
     {
+        $this->loadFromSession();
         return $this->getTokens();
     }
 
     public function queryOne(int $index = 0): ?CsrfToken
     {
+        $this->loadFromSession();
         return $this->getToken($index);
     }
 


### PR DESCRIPTION
The CSRF middleware was returning false negatives.

Related to #77