### PR TITLE
refactor(CsrfToken): calculate expires on when created

### DIFF
--- a/src/CsrfToken.php
+++ b/src/CsrfToken.php
@@ -14,10 +14,13 @@ final class CsrfToken
 {
     private string $token;
 
+    private DateTimeImmutable $expiresOn;
+
     public function __construct(
-        private DateTimeImmutable $createdOn,
-        private int $ttl = 1800,
+        DateTimeImmutable $createdOn,
+        int $ttl = 1800,
     ) {
+        $this->expiresOn = $createdOn->add(new DateInterval("PT{$ttl}S"));
         $this->token = base64_encode(random_bytes(32));
     }
 
@@ -26,7 +29,7 @@ final class CsrfToken
      */
     public function isExpired(): bool
     {
-        return new DateTimeImmutable("now") > $this->createdOn->add(new DateInterval("PT{$this->ttl}S"));
+        return new DateTimeImmutable("now") > $this->expiresOn;
     }
 
     /**


### PR DESCRIPTION
This calculation was previously done in the `isExpired` method.  A new `DateTimeImmutable` object would be created for each call of the `isExpired` method. This could be expensive when the number of tokens to check is large.