### PR TITLE
build(.pre-commit-config.yaml): exclude some files/directories from h…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,15 @@ repos:
     rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
-        exclude: (docs)
+        exclude: (docs|.*\..*lock$|\.vscode|\.phan|^acceptance-test-results\.md$|^LICENSE$)
     -   id: end-of-file-fixer
-        exclude: (docs)
+        exclude: (docs|.*\..*lock$|\.vscode|\.phan|^acceptance-test-results\.md$|^LICENSE$)
     -   id: check-json
+        exclude: .*\..*lock$
     -   id: check-xml
     -   id: check-yaml
     -   id: check-added-large-files
+        exclude: .*\..*lock$
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: v2.35.0
     hooks:


### PR DESCRIPTION
…ooks

Running the pre-commit command took a long time to complete when composer.lock was modified.  It shouldn't process generated files anyhow.