### PR TITLE
fix(CsrfToken): allow negative ttl

### DIFF
--- a/src/CsrfToken.php
+++ b/src/CsrfToken.php
@@ -20,7 +20,10 @@ final class CsrfToken
         DateTimeImmutable $createdOn,
         int $ttl = 1800,
     ) {
-        $this->expiresOn = $createdOn->add(new DateInterval("PT{$ttl}S"));
+        // the valid could be negative
+        $intervalVal = abs($ttl);
+        $secondsToChange = new DateInterval("PT{$intervalVal}S");
+        $this->expiresOn = $ttl > 0 ? $createdOn->add($secondsToChange) : $createdOn->sub($secondsToChange);
         $this->token = base64_encode(random_bytes(32));
     }
 

--- a/tests/unit/CsrfTokenTest.php
+++ b/tests/unit/CsrfTokenTest.php
@@ -51,4 +51,15 @@ final class CsrfTokenTest extends TestCase
         $token = new CsrfToken($createdOn);
         $this->assertFalse($token->isExpired());
     }
+
+    #[TestDox("Shall handle negative ttl values")]
+    public function test5()
+    {
+        $secondsToLive = -1;
+        $token = new CsrfToken(
+            new DateTimeImmutable("now"),
+            $secondsToLive,
+        );
+        $this->assertTrue($token->isExpired());
+    }
 }


### PR DESCRIPTION
Allowing negative ttl improves testability and is less cumbersome than invalidating the instance just because a negative value was provided.