### PR TITLE
test(CsrfTokenGeneratorTest): add namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     - id: php-lint
     - id: php-cs
       files: \.(php)$
-      exclude: (examples|test)
+      exclude: (examples)
       args: ["--standard=PSR1,PSR12,./phpcs.xml", "-p"]
     - id: php-unit
     - id: php-stan

--- a/tests/unit/CsrfTokenGeneratorTest.php
+++ b/tests/unit/CsrfTokenGeneratorTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Phpolar\CsrfProtection\CsrfToken;
-use Phpolar\CsrfProtection\CsrfTokenGenerator;
+namespace Phpolar\CsrfProtection;
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;


### PR DESCRIPTION
The missing namespace was causing the linter to complain in CI.