### PR TITLE
fix: remove logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "phpolar/response-filter": "^0.1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "psr/http-server-middleware": "^1.0",
-        "psr/log": "^2 || ^3"
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "ext-ast": "^1.1",
@@ -87,7 +86,7 @@
         "test:acceptance": "@test --configuration=phpunit.dev.xml --testsuite acceptance",
         "test:acceptance:report": "@test --configuration=phpunit.dev.xml --testsuite acceptance --testdox-text acceptance-test-results.md",
         "test:benchmark": "@test --configuration=phpunit.dev.xml --testsuite benchmark",
-        "test:coverage": "XDEBUG_MODE=coverage composer exec \"@test --coverage-text --testsuite unit\"",
+        "test:coverage": "XDEBUG_MODE=coverage composer exec \"@test --coverage-text --testsuite unit --configuration=phpunit.ci.xml --path-coverage\"",
         "xdebug:on": [
             "TEMP_FILE=\"$(sed --follow-symlink -E 's/^;(zend_extension=xdebug)/\\1/' \"$(php-config --ini-dir)/20-xdebug.ini\")\"; echo \"$TEMP_FILE\" > \"$(php-config --ini-dir)/20-xdebug.ini\""
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72a5debcae19c72996211dd033a6b60b",
+    "content-hash": "cbed99ae3e3911ad18073641ee390fa6",
     "packages": [
         {
             "name": "phpolar/http-codes",
@@ -261,56 +261,6 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/master"
             },
             "time": "2018-10-30T17:12:04+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
-                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/2.0.0"
-            },
-            "time": "2021-07-14T16:41:46+00:00"
         }
     ],
     "packages-dev": [
@@ -2333,6 +2283,56 @@
                 "source": "https://github.com/php-fig/http-factory/tree/master"
             },
             "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
+            },
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Http/CsrfProtectionRequestHandler.php
+++ b/src/Http/CsrfProtectionRequestHandler.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection\Http;
 
-use DateTimeImmutable;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Log\LoggerInterface;
 use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
 use Phpolar\HttpCodes\ResponseCode;
 
@@ -31,7 +29,6 @@ final class CsrfProtectionRequestHandler implements RequestHandlerInterface
     public function __construct(
         private ResponseFactoryInterface $responseFactory,
         private AbstractTokenStorage $storage,
-        private ?LoggerInterface $logger = null,
         private string $requestId = REQUEST_ID_KEY,
         private string $forbiddenMsg = FORBIDDEN_REQUEST_MESSAGE,
     ) {
@@ -118,14 +115,6 @@ final class CsrfProtectionRequestHandler implements RequestHandlerInterface
      */
     private function forbidden(): ResponseInterface
     {
-        if ($this->logger !== null) {
-            $this->logger->warning(
-                sprintf(
-                    $this->forbiddenMsg,
-                    (new DateTimeImmutable("now"))->format(DATE_COOKIE)
-                )
-            );
-        }
         return $this->create(
             ResponseCode::FORBIDDEN,
             self::FORBIDDEN,

--- a/src/Http/CsrfResponseFilterMiddleware.php
+++ b/src/Http/CsrfResponseFilterMiddleware.php
@@ -10,7 +10,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * Adds support for CSRF attack mitigation
@@ -23,7 +22,6 @@ class CsrfResponseFilterMiddleware implements MiddlewareInterface
         private AbstractTokenStorage $storage,
         private CsrfTokenGenerator $tokenGenerator,
         private ResponseFilterStrategyInterface $filterStrategy,
-        private ?LoggerInterface $logger = null,
     ) {
     }
 

--- a/tests/unit/Http/CsrfProtectionRequestHandlerTest.php
+++ b/tests/unit/Http/CsrfProtectionRequestHandlerTest.php
@@ -11,11 +11,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 
 #[CoversClass(CsrfProtectionRequestHandler::class)]
 #[UsesClass(CsrfToken::class)]
@@ -184,25 +182,6 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         ResponseFactoryInterface $responseFactory,
     ) {
         $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
-        $response = $sut->handle($request);
-        $actual = $response->getReasonPhrase();
-        $expected = CsrfProtectionRequestHandler::FORBIDDEN;
-        $this->assertSame($expected, $actual);
-    }
-
-    #[TestDox("Shall log forbidden requests when a logger is provided")]
-    #[DataProviderExternal(CsrfCheckDataProvider::class, "invalidToken")]
-    public function testLogging(
-        ServerRequestInterface $request,
-        AbstractTokenStorage $tokenStorage,
-        ResponseFactoryInterface $responseFactory,
-    ) {
-        /**
-         * @var MockObject|LoggerInterface
-         */
-        $loggerMock = $this->createMock(LoggerInterface::class);
-        $loggerMock->expects($this->atLeastOnce())->method("warning");
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage, $loggerMock);
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::FORBIDDEN;


### PR DESCRIPTION
Consumers of this library can use another middleware for logging.

BREAKING CHANGE: The `CsrfResponseFilterMiddleware` and `CsrfProtectionRequestHandler` will no longer accept a `LoggerInterface` instance as an argument.  Logging invalid requests can be handled in another request handler or middleware.