### PR TITLE
feat(CsrfResponseFilterMiddleware): use response filter instead of re…

### DIFF
--- a/src/Http/CsrfResponseFilterMiddleware.php
+++ b/src/Http/CsrfResponseFilterMiddleware.php
@@ -6,7 +6,7 @@ namespace Phpolar\CsrfProtection\Http;
 
 use Phpolar\CsrfProtection\CsrfTokenGenerator;
 use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
-use Phpolar\Http\Message\ResponseFilterStrategyInterface;
+use Phpolar\Http\Message\ResponseFilterInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -22,7 +22,7 @@ class CsrfResponseFilterMiddleware implements MiddlewareInterface
     public function __construct(
         private AbstractTokenStorage $storage,
         private CsrfTokenGenerator $tokenGenerator,
-        private ResponseFilterStrategyInterface $filterStrategy,
+        private ResponseFilterInterface $responseFilter,
     ) {
     }
 
@@ -39,6 +39,6 @@ class CsrfResponseFilterMiddleware implements MiddlewareInterface
         $token = $this->tokenGenerator->generate();
         $this->storage->add($token);
         $response = $handler->handle($request);
-        return $this->filterStrategy->algorithm($response);
+        return $this->responseFilter->filter($response);
     }
 }

--- a/tests/acceptance/MemoryUsageTest.php
+++ b/tests/acceptance/MemoryUsageTest.php
@@ -10,6 +10,7 @@ use Phpolar\CsrfProtection\Http\CsrfProtectionRequestHandler;
 use Phpolar\CsrfProtection\Http\CsrfResponseFilterMiddleware;
 use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
 use Phpolar\CsrfProtection\Tests\Stubs\MemoryTokenStorageStub;
+use Phpolar\CsrfResponseFilter\Http\Message\CsrfResponseFilter;
 use Phpolar\CsrfResponseFilter\Http\Message\ResponseFilterPatternStrategy;
 use Phpolar\HttpMessageTestUtils\RequestStub;
 use Phpolar\HttpMessageTestUtils\ResponseFactoryStub;
@@ -57,10 +58,12 @@ final class MemoryUsageTest extends TestCase
         $responseFilterMiddleware = new CsrfResponseFilterMiddleware(
             new MemoryTokenStorageStub(),
             new CsrfTokenGenerator(),
-            new ResponseFilterPatternStrategy(
-                $this->token,
-                new StreamFactoryStub("w+"),
-                REQUEST_ID_KEY,
+            new CsrfResponseFilter(
+                new ResponseFilterPatternStrategy(
+                    $this->token,
+                    new StreamFactoryStub("w+"),
+                    REQUEST_ID_KEY,
+                ),
             ),
         );
         $handler = new CsrfProtectionRequestHandler(

--- a/tests/unit/Http/CsrfResponseFilterMiddlewareTest.php
+++ b/tests/unit/Http/CsrfResponseFilterMiddlewareTest.php
@@ -9,6 +9,7 @@ use Phpolar\CsrfProtection\CsrfToken;
 use Phpolar\CsrfProtection\CsrfTokenGenerator;
 use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
 use Phpolar\CsrfProtection\Tests\Stubs\MemoryTokenStorageStub;
+use Phpolar\CsrfResponseFilter\Http\Message\CsrfResponseFilter;
 use Phpolar\CsrfResponseFilter\Http\Message\ResponseFilterPatternStrategy;
 use Phpolar\HttpMessageTestUtils\RequestStub;
 use Phpolar\HttpMessageTestUtils\ResponseFactoryStub;
@@ -78,10 +79,12 @@ final class CsrfResponseFilterMiddlewareTest extends TestCase
         $sut = new CsrfResponseFilterMiddleware(
             $tokenStorage,
             $tokenGenerator,
-            new ResponseFilterPatternStrategy(
-                $validToken,
-                $streamFactory,
-                $this->tokenKey,
+            new CsrfResponseFilter(
+                new ResponseFilterPatternStrategy(
+                    $validToken,
+                    $streamFactory,
+                    $this->tokenKey,
+                ),
             ),
         );
         $responseWithFormKeys = $sut->process($request, $routingHandlerStub);


### PR DESCRIPTION
…sponse filter strategy

This seems to be more intuitive and the library users can swap strategies.  This also allows for removing filter strategies in the future if it is determined to be simpler.

BREAKING CHANGE: Use a response filter to create `CsrfResponseFilterMiddleware` instead of a response filter strategy.