### PR TITLE
fix: add token in handler instead of middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ $preparedResponse = $middleWare->process($request, $routingHandler);
 ## Thresholds
 |Source Code Size|Memory Usage|
 |----------------|------------|
-|4.2 kB|108 kB
+|4.3 kB|108 kB
 
 [Back to top](#csrf-protection)

--- a/acceptance-test-results.md
+++ b/acceptance-test-results.md
@@ -23,5 +23,5 @@
 - [x] Memory usage shall be below 108000 bytes
 
 ## Project Size (Phpolar\CsrfProtection\ProjectSize)
-- [x] Source code total size shall be below 4200 bytes
+- [x] Source code total size shall be below 4300 bytes
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php-coveralls/php-coveralls": "^2.5",
         "phpmd/phpmd": "^2.13",
         "phpolar/csrf-response-filter": "^1.0",
-        "phpolar/http-message-test-utils": "^0.1.0",
+        "phpolar/http-message-test-utils": "^0.2.0",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^10.0",
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c220e275831dc647fc42c1357c67764",
+    "content-hash": "6b2774a301be16a94581c064ba138fc8",
     "packages": [
         {
             "name": "phpolar/http-codes",
@@ -568,16 +568,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.5.1",
+            "version": "7.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b964ca597e86b752cd994f27293e9fa6b6a95ed9"
+                "reference": "8444a2bacf1960bc6a2b62ed86b8e72e11eebe51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b964ca597e86b752cd994f27293e9fa6b6a95ed9",
-                "reference": "b964ca597e86b752cd994f27293e9fa6b6a95ed9",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8444a2bacf1960bc6a2b62ed86b8e72e11eebe51",
+                "reference": "8444a2bacf1960bc6a2b62ed86b8e72e11eebe51",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -676,7 +673,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.5.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.6.1"
             },
             "funding": [
                 {
@@ -692,7 +689,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:30:08+00:00"
+            "time": "2023-05-15T20:43:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1051,16 +1048,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -1101,9 +1098,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -1738,16 +1735,16 @@
         },
         {
             "name": "phpolar/http-message-test-utils",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpolar/http-message-test-utils.git",
-                "reference": "fae8687423037f4edaf528949f383c52fdd290cd"
+                "reference": "8a9ca71989ede20dfa14e889421c82a8e2af120c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpolar/http-message-test-utils/zipball/fae8687423037f4edaf528949f383c52fdd290cd",
-                "reference": "fae8687423037f4edaf528949f383c52fdd290cd",
+                "url": "https://api.github.com/repos/phpolar/http-message-test-utils/zipball/8a9ca71989ede20dfa14e889421c82a8e2af120c",
+                "reference": "8a9ca71989ede20dfa14e889421c82a8e2af120c",
                 "shasum": ""
             },
             "require": {
@@ -1773,28 +1770,29 @@
             "description": "A PSR-7 Http Message Stub Library",
             "support": {
                 "issues": "https://github.com/phpolar/http-message-test-utils/issues",
-                "source": "https://github.com/phpolar/http-message-test-utils/tree/0.1.0"
+                "source": "https://github.com/phpolar/http-message-test-utils/tree/0.2.0"
             },
-            "time": "2023-04-30T01:12:14+00:00"
+            "time": "2023-05-21T07:04:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.4",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
+                "reference": "6df62b08faef4f899772bc7c3bbabb93d2b7a21c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
-                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6df62b08faef4f899772bc7c3bbabb93d2b7a21c",
+                "reference": "6df62b08faef4f899772bc7c3bbabb93d2b7a21c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
+                "nikic/php-parser": "^4.15",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
@@ -1818,9 +1816,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.21.0"
             },
-            "time": "2023-05-02T09:19:37+00:00"
+            "time": "2023-05-17T13:13:44+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/docs/classes/Phpolar-CsrfProtection-Http-CsrfProtectionRequestHandler.html
+++ b/docs/classes/Phpolar-CsrfProtection-Http-CsrfProtectionRequestHandler.html
@@ -123,7 +123,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">19</span>
+    <span class="phpdocumentor-element-found-in__line">20</span>
 
     </aside>
 
@@ -224,7 +224,7 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">21</span>
+    <span class="phpdocumentor-element-found-in__line">22</span>
 
     </aside>
 
@@ -253,7 +253,7 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">22</span>
+    <span class="phpdocumentor-element-found-in__line">23</span>
 
     </aside>
 
@@ -282,7 +282,7 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">23</span>
+    <span class="phpdocumentor-element-found-in__line">24</span>
 
     </aside>
 
@@ -311,7 +311,7 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">25</span>
+    <span class="phpdocumentor-element-found-in__line">26</span>
 
     </aside>
 
@@ -340,7 +340,7 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">24</span>
+    <span class="phpdocumentor-element-found-in__line">25</span>
 
     </aside>
 
@@ -382,22 +382,22 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">29</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Message\ResponseFactoryInterface">ResponseFactoryInterface</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$responseFactory</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-Storage-AbstractTokenStorage.html"><abbr title="\Phpolar\CsrfProtection\Storage\AbstractTokenStorage">AbstractTokenStorage</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$storage</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$requestId</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">REQUEST_ID_KEY</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-CsrfToken.html"><abbr title="\Phpolar\CsrfProtection\CsrfToken">CsrfToken</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$token</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-Storage-AbstractTokenStorage.html"><abbr title="\Phpolar\CsrfProtection\Storage\AbstractTokenStorage">AbstractTokenStorage</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$storage</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Message\ResponseFactoryInterface">ResponseFactoryInterface</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$responseFactory</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$requestId</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">REQUEST_ID_KEY</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
         <section class="phpdocumentor-description"></section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$responseFactory</span>
-                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Message\ResponseFactoryInterface">ResponseFactoryInterface</abbr></span>
+                <span class="phpdocumentor-signature__argument__name">$token</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-CsrfToken.html"><abbr title="\Phpolar\CsrfProtection\CsrfToken">CsrfToken</abbr></a></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>
@@ -406,6 +406,14 @@ of the request.</dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$storage</span>
                 : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-Storage-AbstractTokenStorage.html"><abbr title="\Phpolar\CsrfProtection\Storage\AbstractTokenStorage">AbstractTokenStorage</abbr></a></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"></section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$responseFactory</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\Psr\Http\Message\ResponseFactoryInterface">ResponseFactoryInterface</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"></section>
@@ -442,7 +450,7 @@ of the request.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfProtectionRequestHandler.php"><a href="files/http-csrfprotectionrequesthandler.html"><abbr title="Http/CsrfProtectionRequestHandler.php">CsrfProtectionRequestHandler.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">40</span>
+    <span class="phpdocumentor-element-found-in__line">42</span>
 
     </aside>
 

--- a/docs/classes/Phpolar-CsrfProtection-Http-CsrfResponseFilterMiddleware.html
+++ b/docs/classes/Phpolar-CsrfProtection-Http-CsrfResponseFilterMiddleware.html
@@ -123,7 +123,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfResponseFilterMiddleware.php"><a href="files/http-csrfresponsefiltermiddleware.html"><abbr title="Http/CsrfResponseFilterMiddleware.php">CsrfResponseFilterMiddleware.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">20</span>
+    <span class="phpdocumentor-element-found-in__line">18</span>
 
     </aside>
 
@@ -199,35 +199,19 @@ response.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfResponseFilterMiddleware.php"><a href="files/http-csrfresponsefiltermiddleware.html"><abbr title="Http/CsrfResponseFilterMiddleware.php">CsrfResponseFilterMiddleware.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">22</span>
+    <span class="phpdocumentor-element-found-in__line">20</span>
 
     </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-CsrfToken.html"><abbr title="\Phpolar\CsrfProtection\CsrfToken">CsrfToken</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$token</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-Storage-AbstractTokenStorage.html"><abbr title="\Phpolar\CsrfProtection\Storage\AbstractTokenStorage">AbstractTokenStorage</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$storage</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Phpolar\Http\Message\ResponseFilterInterface">ResponseFilterInterface</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$responseFilter</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Phpolar\Http\Message\ResponseFilterInterface">ResponseFilterInterface</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$responseFilter</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
         <section class="phpdocumentor-description"></section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
-                    <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$token</span>
-                : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-CsrfToken.html"><abbr title="\Phpolar\CsrfProtection\CsrfToken">CsrfToken</abbr></a></span>
-                            </dt>
-            <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"></section>
-
-            </dd>
-                    <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$storage</span>
-                : <span class="phpdocumentor-signature__argument__return-type"><a href="classes/Phpolar-CsrfProtection-Storage-AbstractTokenStorage.html"><abbr title="\Phpolar\CsrfProtection\Storage\AbstractTokenStorage">AbstractTokenStorage</abbr></a></span>
-                            </dt>
-            <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"></section>
-
-            </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$responseFilter</span>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\Phpolar\Http\Message\ResponseFilterInterface">ResponseFilterInterface</abbr></span>
@@ -259,7 +243,7 @@ response.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="Http/CsrfResponseFilterMiddleware.php"><a href="files/http-csrfresponsefiltermiddleware.html"><abbr title="Http/CsrfResponseFilterMiddleware.php">CsrfResponseFilterMiddleware.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">37</span>
+    <span class="phpdocumentor-element-found-in__line">33</span>
 
     </aside>
 

--- a/phpunit.dev.xml
+++ b/phpunit.dev.xml
@@ -14,7 +14,7 @@
   <coverage/>
   <php>
     <const name="SRC_GLOB" value="/src{/,/**/}*.php"/>
-    <const name="PROJECT_SIZE_THRESHOLD" value="4200"/>
+    <const name="PROJECT_SIZE_THRESHOLD" value="4300"/>
     <const name="PROJECT_MEMORY_USAGE_THRESHOLD" value="108000"/>
   </php>
   <source>

--- a/src/Http/CsrfProtectionRequestHandler.php
+++ b/src/Http/CsrfProtectionRequestHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection\Http;
 
+use Phpolar\CsrfProtection\CsrfToken;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -27,8 +28,9 @@ final class CsrfProtectionRequestHandler implements RequestHandlerInterface
     private const UNSAFE_METHODS = ["DELETE", "PUT", "GET", "POST"];
 
     public function __construct(
-        private ResponseFactoryInterface $responseFactory,
+        private CsrfToken $token,
         private AbstractTokenStorage $storage,
+        private ResponseFactoryInterface $responseFactory,
         private string $requestId = REQUEST_ID_KEY,
     ) {
     }
@@ -48,6 +50,7 @@ final class CsrfProtectionRequestHandler implements RequestHandlerInterface
         if (in_array($method, self::UNSAFE_METHODS) === true) {
             if ($method === "GET") {
                 if (count($request->getQueryParams()) === 0) {
+                    $this->storage->add($this->token);
                     return $this->success();
                 }
             }
@@ -62,6 +65,7 @@ final class CsrfProtectionRequestHandler implements RequestHandlerInterface
                         self::CREATED,
                     );
                 }
+                $this->storage->add($this->token);
                 return $this->success();
             }
             return $this->forbidden();

--- a/src/Http/CsrfResponseFilterMiddleware.php
+++ b/src/Http/CsrfResponseFilterMiddleware.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection\Http;
 
-use Phpolar\CsrfProtection\CsrfToken;
-use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
 use Phpolar\Http\Message\ResponseFilterInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -20,8 +18,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 class CsrfResponseFilterMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private CsrfToken $token,
-        private AbstractTokenStorage $storage,
         private ResponseFilterInterface $responseFilter,
     ) {
     }
@@ -38,7 +34,6 @@ class CsrfResponseFilterMiddleware implements MiddlewareInterface
         ServerRequestInterface $request,
         RequestHandlerInterface $handler
     ): ResponseInterface {
-        $this->storage->add($this->token);
         $response = $handler->handle($request);
         return $this->responseFilter->filter($response);
     }

--- a/tests/acceptance/CsrfProtectionTest.php
+++ b/tests/acceptance/CsrfProtectionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection\Http;
 
+use DateTimeImmutable;
+use Phpolar\CsrfProtection\CsrfToken;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,7 +30,11 @@ final class CsrfProtectionTest extends TestCase
         ResponseFactoryInterface $responseFactory,
         string $requestType // variable used in testdox input
     ) {
-        $handler = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $handler = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $handler->handle($request);
         $this->assertSame(
             400,
@@ -45,7 +51,11 @@ final class CsrfProtectionTest extends TestCase
         ResponseFactoryInterface $responseFactory,
         string $requestType // variable used in testdox input
     ) {
-        $handler = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $handler = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $handler->handle($request);
         $this->assertSame(
             403,
@@ -63,7 +73,11 @@ final class CsrfProtectionTest extends TestCase
         int $expectedCode,
         string $requestType // variable used in testdox input
     ) {
-        $handler = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $handler = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $handler->handle($request);
         $this->assertSame(
             $expectedCode,

--- a/tests/acceptance/MemoryUsageTest.php
+++ b/tests/acceptance/MemoryUsageTest.php
@@ -56,8 +56,6 @@ final class MemoryUsageTest extends TestCase
     public function shallBeBelowThreshold(int $threshold)
     {
         $responseFilterMiddleware = new CsrfResponseFilterMiddleware(
-            $this->token,
-            new MemoryTokenStorageStub(),
             new CsrfResponseFilter(
                 new ResponseFilterPatternStrategy(
                     $this->token,
@@ -67,8 +65,9 @@ final class MemoryUsageTest extends TestCase
             ),
         );
         $handler = new CsrfProtectionRequestHandler(
-            new ResponseFactoryStub(),
+            $this->token,
             new MemoryTokenStorageStub(),
+            new ResponseFactoryStub(),
         );
         $request = new RequestStub();
         /**

--- a/tests/unit/Http/CsrfProtectionRequestHandlerTest.php
+++ b/tests/unit/Http/CsrfProtectionRequestHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection\Http;
 
+use DateTimeImmutable;
 use Phpolar\CsrfProtection\CsrfToken;
 use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
 use Phpolar\CsrfProtection\Tests\DataProviders\CsrfCheckDataProvider;
@@ -27,7 +28,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::CREATED;
@@ -41,7 +46,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -55,7 +64,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -69,7 +82,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -83,7 +100,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -97,7 +118,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::METHOD_NOT_ALLOWED;
@@ -111,7 +136,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -125,7 +154,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -139,7 +172,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -153,7 +190,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::OK;
@@ -168,7 +209,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         ResponseFactoryInterface $responseFactory,
         string $requestMethod, // used for test dox output
     ) {
-            $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::BAD_REQUEST;
@@ -183,7 +228,11 @@ final class CsrfProtectionRequestHandlerTest extends TestCase
         ResponseFactoryInterface $responseFactory,
         string $requestMethod, // used for test dox output
     ) {
-        $sut = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $sut = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $response = $sut->handle($request);
         $actual = $response->getReasonPhrase();
         $expected = CsrfProtectionRequestHandler::FORBIDDEN;

--- a/tests/unit/Http/CsrfRequestCheckMiddlewareTest.php
+++ b/tests/unit/Http/CsrfRequestCheckMiddlewareTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpolar\CsrfProtection\Http;
 
+use DateTimeImmutable;
 use Phpolar\CsrfProtection\CsrfToken;
 use Phpolar\CsrfProtection\Storage\AbstractTokenStorage;
 use Phpolar\CsrfProtection\Tests\DataProviders\CsrfCheckDataProvider;
@@ -45,7 +46,11 @@ final class CsrfRequestCheckMiddlewareTest extends TestCase
         AbstractTokenStorage $tokenStorage,
         ResponseFactoryInterface $responseFactory,
     ) {
-        $handler = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $handler = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $handlerStub = new class () implements RequestHandlerInterface {
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
@@ -66,7 +71,11 @@ final class CsrfRequestCheckMiddlewareTest extends TestCase
         ResponseFactoryInterface $responseFactory,
     ) {
         $expectedResponseContent = "The request is safe!";
-        $handler = new CsrfProtectionRequestHandler($responseFactory, $tokenStorage);
+        $handler = new CsrfProtectionRequestHandler(
+            new CsrfToken(new DateTimeImmutable("now")),
+            $tokenStorage,
+            $responseFactory,
+        );
         $handlerStub = new class ($expectedResponseContent) implements RequestHandlerInterface {
             public function __construct(private string $expectedResponseContent)
             {

--- a/tests/unit/Http/CsrfResponseFilterMiddlewareTest.php
+++ b/tests/unit/Http/CsrfResponseFilterMiddlewareTest.php
@@ -53,7 +53,8 @@ final class CsrfResponseFilterMiddlewareTest extends TestCase
         HTML;
 
         $streamFactory = new StreamFactoryStub("w+");
-        $responseFactory = new ResponseFactoryStub($streamFactory->createStream($template));
+        $this->stream = $streamFactory->createStream($template);
+        $responseFactory = new ResponseFactoryStub($this->stream);
         $tokenStorage = new MemoryTokenStorageStub();
 
         $validToken = new CsrfToken(new DateTimeImmutable("now"));


### PR DESCRIPTION
Authentication redirects were causing the token to fill beyond capacity.  The handler already had the request handling logic.

BREAKING CHANGE: Inject token in request handler instead of request middleware.

Closes #77 