### PR TITLE
fix(AbstractTokenStorage): do not add tokens more than once

### DIFF
--- a/src/Storage/AbstractTokenStorage.php
+++ b/src/Storage/AbstractTokenStorage.php
@@ -23,8 +23,12 @@ abstract class AbstractTokenStorage
      */
     public function add(CsrfToken $token): void
     {
-        $maxTokens = $this->getMaxCount();
-        if (count($this->tokens) >= $maxTokens) {
+        $alreadyContains = array_search($token, $this->tokens) !== false;
+        $alreadyAtCountThreshold = count($this->tokens) >= $this->getMaxCount();
+        if ($alreadyContains === true) {
+            return;
+        }
+        if ($alreadyAtCountThreshold === true) {
             array_shift($this->tokens);
         }
         array_push($this->tokens, $token);

--- a/tests/unit/Storage/AbstractTokenStorageTest.php
+++ b/tests/unit/Storage/AbstractTokenStorageTest.php
@@ -140,4 +140,15 @@ final class AbstractTokenStorageTest extends TestCase
         $token = new CsrfToken(new DateTimeImmutable());
         $this->assertFalse($sut->isValid((string) $token));
     }
+
+    #[TestDox("Shall not add a token if it already is in storage")]
+    public function test8()
+    {
+        $sut = new MemoryTokenStorageStub();
+        $tokenA = new CsrfToken(new DateTimeImmutable());
+        $tokenB = $tokenA;
+        $sut->add($tokenA);
+        $sut->add($tokenB);
+        $this->assertCount(1, $sut->queryAll());
+    }
 }


### PR DESCRIPTION
The same instance should never be added more than once to the storage.

Issue #84