### PR TITLE
fix(SessionTokenStorage): allow adding tokens after max count thresho…

### DIFF
--- a/src/Storage/SessionTokenStorage.php
+++ b/src/Storage/SessionTokenStorage.php
@@ -42,13 +42,11 @@ final class SessionTokenStorage extends AbstractTokenStorage
 
     public function queryAll(): array
     {
-        $this->loadFromSession();
         return $this->getTokens();
     }
 
     public function queryOne(int $index = 0): ?CsrfToken
     {
-        $this->loadFromSession();
         return $this->getToken($index);
     }
 

--- a/tests/unit/Storage/AbstractTokenStorageTest.php
+++ b/tests/unit/Storage/AbstractTokenStorageTest.php
@@ -118,7 +118,20 @@ final class AbstractTokenStorageTest extends TestCase
             $sut->add($token);
         }
         $tokens = $sut->queryAll();
-        $this->assertCount(TOKEN_MAX, $tokens);
+        $this->assertCount($tokenMax, $tokens);
+    }
+
+    #[TestDox("Shall allow a token to be added after max count threshold has been reached")]
+    #[DataProvider("tooManyTokens")]
+    public function test5a(array $excessiveTokens)
+    {
+        $sut = new MemoryTokenStorageStub();
+        foreach ($excessiveTokens as $token) {
+            $sut->add($token);
+        }
+        $lastToken = new CsrfToken(new DateTimeImmutable("now"));
+        $sut->add($lastToken);
+        $this->assertContainsEquals($lastToken, $sut->queryAll());
     }
 
     #[TestDox("Shall say a token is valid if it contains an expired twin")]


### PR DESCRIPTION
…ld is reached

Tokens were not being added to storage after the max token count threshold was reached.  This was causing the request check middleware to incorrectly forbid requests.